### PR TITLE
Remove duplicate slash from API requests

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -12,8 +12,8 @@ Vue.use(VueResource);
 // Vue.http.options.crossOrigin = true;
 // Vue.http.options.xhr = { withCredentials: true };
 const API_ROOT = 'https://api.modify.sg/';
-const ModulesListResource = Vue.resource(`${API_ROOT}modulesList/{/school}/{/year}/{/sem}`);
-const ModuleResource = Vue.resource(`${API_ROOT}modules/{/school}/{/year}/{/sem}/{/moduleCode}`);
+const ModulesListResource = Vue.resource(`${API_ROOT}modulesList/{school}/{year}/{sem}`);
+const ModuleResource = Vue.resource(`${API_ROOT}modules/{school}/{year}/{sem}/{moduleCode}`);
 
 function getFromForage(key, apiCall) {
   return localforage.getItem(key).then((value) => {


### PR DESCRIPTION
<img width="417" alt="screen shot 2016-08-19 at 10 59 40 am" src="https://cloud.githubusercontent.com/assets/1315101/17797561/4525a83e-65fc-11e6-864e-fa2ec94ee3b9.png">

Not sure where the slash should be removed but personally I find it clearer to leave the slash out of the variable 😄 
